### PR TITLE
Change dependencies to geopandas-base instead of geopandas

### DIFF
--- a/ci/envs/310-latest.yaml
+++ b/ci/envs/310-latest.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python =3.10
   - pip
   # required
-  - geopandas
+  - geopandas-base
   - shapely >1
   - topojson
   # testing

--- a/ci/envs/311-latest.yaml
+++ b/ci/envs/311-latest.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python =3.11
   - pip
   # required
-  - geopandas
+  - geopandas-base
   - shapely >1
   - topojson
   # testing

--- a/ci/envs/38-latest.yaml
+++ b/ci/envs/38-latest.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python =3.8
   - pip
   # required
-  - geopandas
+  - geopandas-base
   - shapely >1
   - topojson
   # testing

--- a/ci/envs/38-minimal-pygeos.yaml
+++ b/ci/envs/38-minimal-pygeos.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python =3.8
   - pip
   # required
-  - geopandas
+  - geopandas-base
   - pygeos
   - shapely >1
   - topojson

--- a/ci/envs/39-latest.yaml
+++ b/ci/envs/39-latest.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python =3.9
   - pip
   # required
-  - geopandas
+  - geopandas-base
   - shapely >1
   - topojson
   # testing

--- a/ci/envs/readthedocs.yml
+++ b/ci/envs/readthedocs.yml
@@ -5,7 +5,7 @@ dependencies:
   - python =3.10
   - pip
   # required
-  - geopandas
+  - geopandas-base
   - shapely >1
   - topojson
   # docs

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -5,7 +5,7 @@ dependencies:
   - python =3.10
   - pip
   # required
-  - geopandas
+  - geopandas-base
   - shapely >1
   - topojson
   # testing


### PR DESCRIPTION
Speeds up tests because fiona, gdal,... aren't installed anymore.

Remark: only possible for conda dependencies, not for pip, as there doesn't exist a geopandas-base pip package.