### PR TITLE
Fix `collection_extract` and `collect` creating invalid multipolygons in some cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Add support for Z/M dimensions geometries in `GeometryType` (#63)
 - Add support for 0 dim ndarray input (#60)
 
+### Bugs fixed
+
+ - Fix `collection_extract` and `collect` creating invalid multipolygons in some cases (#65)
+
 ## 0.3.0 (2023-09-07)
 
 ### Improvements

--- a/pygeoops/_general.py
+++ b/pygeoops/_general.py
@@ -361,7 +361,10 @@ def make_valid(geometry, keep_collapsed: bool = True, only_if_invalid: bool = Fa
             result = _extract_0dim_ndarray(result)
         else:
             # No make_valid needed, but copy because we're supposed to return a copy
-            result = copy.deepcopy(geometry)
+            if not hasattr(geometry, "__len__"):
+                result = copy.deepcopy(geometry)
+            else:
+                result = np.array(geometry)
 
     else:
         result = _make_valid(geometry, keep_collapsed)

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -379,6 +379,8 @@ def test_is_iterable_arraylike(test_id, input, expected):
         (np.array(MULTIPOLY_INVALID_1_COLLAPSING_LINE), False, shapely.MultiPolygon),
         (None, False, None),
         (np.array(None), True, None),
+        (shapely.box(0, 0, 5, 5), False, shapely.Polygon),
+        (np.array(shapely.box(0, 0, 5, 5)), True, shapely.Polygon),
     ],
 )
 def test_makevalid_keep_collapsed(
@@ -417,6 +419,14 @@ def test_makevalid_keep_collapsed(
             ],
             False,
             [shapely.MultiPolygon, shapely.LineString],
+        ),
+        (
+            [
+                shapely.box(0, 0, 1, 1),
+                shapely.box(5, 0, 6, 1),
+            ],
+            False,
+            [shapely.Polygon, shapely.Polygon],
         ),
     ],
 )


### PR DESCRIPTION
If collection_extract and/or collect were ran on a collection/list of adjacent/touching polygons, they were put together as a multipolygon. However, the rings of a multipolygon should not touch.

Now in this case a geometrycollection containing those polygons is created.