### PR TITLE
Improve performance of difference_all by unioning geometries_to_substract instead of looping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add `make_valid` with `keep_collapsed` parameter (#58)
 - Add support for Z/M dimensions geometries in `GeometryType` (#63)
 - Add support for 0 dim ndarray input (#60)
+- Improve performance of `difference_all` and `difference_all_tiled` (#67)
 
 ### Bugs fixed
 

--- a/tests/test_difference.py
+++ b/tests/test_difference.py
@@ -35,14 +35,14 @@ def test_difference_all():
     # -------------------------------------------------
     small2 = shapely.Polygon([(45, 0), (50, 0), (50, 5), (45, 5), (45, 0)])
     assert pygeoops.difference_all(large, [small, small2]) == shapely.difference(
-        shapely.difference(large, small), small2
+        large, shapely.union_all([small, small2])
     )
     assert pygeoops.difference_all(line, [small, small2]) == shapely.difference(
-        shapely.difference(line, small), small2
+        line, shapely.union_all([small, small2])
     )
     collection = shapely.GeometryCollection([line, large])
     assert pygeoops.difference_all(collection, [small, small2]) == shapely.difference(
-        shapely.difference(collection, small), small2
+        collection, shapely.union_all([small, small2])
     )
 
     # Tests with keep_geom_type
@@ -107,7 +107,7 @@ def test_difference_all_tiled():
     # Subtract multiple geometries from single geometry
     small2 = shapely.Polygon([(45, 0), (50, 0), (50, 5), (45, 5), (45, 0)])
     assert pygeoops.difference_all_tiled(large, [small, small2]) == shapely.difference(
-        shapely.difference(large, small), small2
+        large, shapely.union_all([small, small2])
     )
 
 


### PR DESCRIPTION
difference of unioned `geometries_to_substract` is significantly faster than doing the differnence in a loop.