### PR TITLE
ENH: improve logging of geos warnings in `difference_all`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Improvements
 
-- Improve logging of geos warnings (#77)
+- Improve logging of geos warnings in `difference_all` (#77)
 - Use ruff instead of black for formatting + use mypy (#78)
 
 ## 0.4.0 (2023-10-31)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # CHANGELOG
 
-## 0.4.0 (???)
+## 0.5.0 (???)
+
+### Improvements
+
+- ENH: improve logging of geos warnings (#77)
+
+## 0.4.0 (2023-10-31)
 
 ### Improvements
 


### PR DESCRIPTION
shapely.difference throws e.g. "divide by zero" warnings that are coming up from geos, but there is no information regarding the relevant polygon/point/... This adds extra logging to be able to identify the polygon combination causing the warning.

An issue was opened for an example of the divide by zero's occuring: https://github.com/libgeos/geos/issues/1048