### PR TITLE
MAINT: add some missing explicit dependencies

### DIFF
--- a/ci/envs/latest-no-optional-deps.yml
+++ b/ci/envs/latest-no-optional-deps.yml
@@ -5,6 +5,8 @@ dependencies:
   - python
   # required
   - geopandas-base >=0.12.1
+  - numpy
+  - pyproj
   - shapely >1
   - topojson
   # testing

--- a/ci/envs/latest.yml
+++ b/ci/envs/latest.yml
@@ -6,6 +6,8 @@ dependencies:
   - pip
   # required
   - geopandas-base >=0.12.1
+  - numpy
+  - pyproj
   - shapely >1
   - topojson
   # testing

--- a/ci/envs/minimal-pygeos.yml
+++ b/ci/envs/minimal-pygeos.yml
@@ -6,6 +6,8 @@ dependencies:
   - pip
   # required
   - geopandas-base =0.12.1
+  - numpy
+  - pyproj
   - pygeos
   - shapely =2.0.1
   - topojson

--- a/ci/envs/readthedocs.yml
+++ b/ci/envs/readthedocs.yml
@@ -6,6 +6,8 @@ dependencies:
   - pip
   # required
   - geopandas-base >=0.12.1
+  - numpy
+  - pyproj
   - shapely >1
   - topojson
   # docs

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -6,6 +6,8 @@ dependencies:
   - pip
   # required
   - geopandas-base >=0.12.1
+  - numpy
+  - pyproj
   - shapely >1
   - topojson
   # benchmark

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 ]
 dependencies = [
     "geopandas>=0.12.1",
+    "pyproj",
     "shapely>1",
     "topojson",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 ]
 dependencies = [
     "geopandas>=0.12.1",
+    "numpy",
     "pyproj",
     "shapely>1",
     "topojson",


### PR DESCRIPTION
Because geopandas 1.0 reduced its mandatory dependencies, it now shows that there are gaps in the dependencies defined in pygeoops: numpy, pyproj 