### PR TITLE
MAINT: avoid some irrelevant type errors being shown

### DIFF
--- a/benchmark/reporter.py
+++ b/benchmark/reporter.py
@@ -12,6 +12,8 @@ import numpy as np
 import pandas as pd
 import pandas.api
 
+# mypy: disable-error-code="operator"
+
 A4_LONG_SIDE = 11.69
 A4_SHORT_SIDE = 8.27
 

--- a/pygeoops/_centerline.py
+++ b/pygeoops/_centerline.py
@@ -11,6 +11,7 @@ from shapely.geometry.base import BaseGeometry
 from pygeoops._general import _extract_0dim_ndarray
 from pygeoops import _extend_line
 
+
 logger = logging.getLogger(__name__)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,13 +33,13 @@ full = ["simplification"]
 "Homepage" = "https://github.com/pygeoops/pygeoops"
 "Bug Tracker" = "https://github.com/pygeoops/pygeoops/issues"
 
-[tool.black]
-line-length = 88
-
 [tool.mypy]
 [[tool.mypy.overrides]]
 module = "geofileops.*,geopandas.*,matplotlib.*,setuptools.*,simplification.*,shapely.*,topojson.*"
 ignore_missing_imports = true
+
+[tool.pyright]
+typeCheckingMode = "off"
 
 [tool.pytest.ini_options]
 pythonpath = "."


### PR DESCRIPTION
- mypy showed some typing errors for benchmark.reporter.py, which isn't relevant, so disable them.
- add setting to pyprojects.toml to explicitly disable pyright type checking so not needed anymore in vscode settings.