### PR TITLE
CI: use pre-commit-ci instead of via action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,18 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  Linting:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - uses: pre-commit/action@v3.0.1
-
   Test:
-    needs: Linting
     name: ${{ matrix.os }} - ${{ matrix.env }} (python ${{ matrix.python }})
     timeout-minutes: 10
     runs-on: ${{ matrix.os }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ci:
     autofix_prs: false
-    autoupdate_schedule: weekly
+    autoupdate_schedule: quarterly
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
Using the action is in maintenance only mode, and the advice is to use pre-commit-ci instead: https://github.com/pre-commit/action