### PR TITLE
ENH: improve error raised by centerline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   (#83, #89)
 - Add option to function `centerline` to extend it to the polygon boundary (#87)
 - Improve logging of geos warnings in `difference_all` (#77)
-- Improve error raised by `centerline` (#116)
+- Add more context to errors raised by `centerline` (#116)
 - Change minimal python version to 3.9 (#84)
 - Use ruff instead of black for formatting + use mypy (#78)
 - Enable extra linter checks like pydocstyle and pyupgrade (#85)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   (#83, #89)
 - Add option to function `centerline` to extend it to the polygon boundary (#87)
 - Improve logging of geos warnings in `difference_all` (#77)
+- Improve error raised by `centerline` (#116)
 - Change minimal python version to 3.9 (#84)
 - Use ruff instead of black for formatting + use mypy (#78)
 - Enable extra linter checks like pydocstyle and pyupgrade (#85)

--- a/pygeoops/_centerline.py
+++ b/pygeoops/_centerline.py
@@ -126,7 +126,7 @@ def _centerline(
 
         # Only keep edges that are covered by the original geometry to remove edges
         # going to infinity,...
-        # Remark: contains is optimized for prepared geometries <> within -> a lot faster!
+        # Remark: contains is optimized for prepared geometries <> within -> faster!
         edges = shapely.get_parts(voronoi_edges)
         shapely.prepare(geom)
         edges = edges[shapely.contains(geom, edges)]


### PR DESCRIPTION
Include the first point of the geometry that triggered the error.