### PR TITLE
CI: add dev-deps environment to test on

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,10 @@ jobs:
             os: ubuntu-latest
             dev: false
             python: "3.12"
+          - env: dev-deps
+            os: ubuntu-latest
+            dev: false
+            python: "3.12"
           - env: latest
             os: macos-latest
             dev: false

--- a/ci/envs/dev-deps.yml
+++ b/ci/envs/dev-deps.yml
@@ -1,6 +1,6 @@
 name: pygeoops-dev-deps
 channels:
-  - shapely_dev
+  - conda-forge/label/shapely_dev
   - conda-forge
 dependencies:
   - python

--- a/ci/envs/dev-deps.yml
+++ b/ci/envs/dev-deps.yml
@@ -1,6 +1,6 @@
 name: pygeoops-dev-deps
 channels:
-  - shapely-dev
+  - shapely_dev
   - conda-forge
 dependencies:
   - python

--- a/ci/envs/dev-deps.yml
+++ b/ci/envs/dev-deps.yml
@@ -1,0 +1,19 @@
+name: pygeoops-dev-deps
+channels:
+  - shapely-dev
+  - conda-forge
+dependencies:
+  - python
+  - pip
+  # required
+  - geopandas-base >=0.12.1
+  - numpy
+  - pyproj
+  - shapely >1
+  - topojson
+  # optional
+  - simplification
+  # testing
+  - matplotlib
+  - pytest
+  - pytest-cov


### PR DESCRIPTION
Run the CI tests also on an environment with the development version of dependencies (if available).